### PR TITLE
GraphQL over WebSocket Protocol

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -66,12 +66,14 @@ Direction: **Client -> Server**
 Requests a operation specified in the message `payload`. This message leverages the unique ID field to connect future server messages to the operation started by this message.
 
 ```typescript
+import { DocumentNode } from 'graphql';
+
 interface SubscribeMessage {
   id: '<unique-operation-id>';
   type: 'subscribe';
   payload: {
     operationName: string;
-    query: string;
+    query: string | DocumentNode;
     variables: Record<string, unknown>;
   };
 }

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -20,35 +20,6 @@ The server can terminate the socket (kick the client off) at any time. The close
 
 The client terminates the socket and closes the connection by dispatching a `1000: Normal Closure` close event to the server indicating a normal closure.
 
-```typescript
-import { ExecutionResult, GraphQLError } from 'graphql';
-
-interface Message {
-  id?: string;
-  type: MessageType;
-  payload?:
-    | SubscribeOperation // Client -> Server
-    | ExecutionResult // Server -> Client
-    | GraphQLError; // Server -> Client
-}
-
-enum MessageType {
-  ConnectionInit = 'connection_init', // Client -> Server
-  ConnectionAck = 'connection_ack', // Server -> Client
-
-  Subscribe = 'subscribe', // Client -> Server
-  Next = 'next', // Server -> Client
-  Error = 'error', // Server -> Client
-  Complete = 'complete', // Client -> Server
-}
-
-interface SubscribeOperation {
-  operationName: string;
-  query: string;
-  variables: Record<string, unknown>;
-}
-```
-
 ## Message types
 
 ### `ConnectionInit`
@@ -64,7 +35,7 @@ The server must receive the connection initialisation message within the allowed
 ```typescript
 interface ConnectionInitMessage {
   type: 'connection_init';
-  payload?: Record<string, any>; // connectionParams
+  payload?: Record<string, unknown>; // connectionParams
 }
 ```
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -200,7 +200,7 @@ For the sake of clarity, the following examples demonstrate the communication pr
 _The client and the server has already gone through [successful connection initialisation](#successful-connection-initialisation)._
 
 1. _Client_ generates a unique ID for the following operation
-2. _Client_ dispatches the `Start` message with the, previously generated, unique ID through the `id` field and the requested subscription operation passed through the `payload` field
+2. _Client_ dispatches the `Subscribe` message with the, previously generated, unique ID through the `id` field and the requested subscription operation passed through the `payload` field
 3. _Server_ validates the request through the `onSubscribe` callback and accepts it
 4. _Server_ establishes a GraphQL subscription and listens for events in the source stream
 5. _Server_ dispatches `Next` messages for every event in the underlying subscription source stream matching the client's unique ID

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -162,47 +162,48 @@ For the sake of clarity, the following examples demonstrate the communication pr
 <h3 id="successful-connection-initialisation">Successful connection initialisation</h3>
 
 1. _Client_ sends a WebSocket handshake request with the sub-protocol: `graphql-subscriptions-ws`
-2. _Server_ accepts the handshake and establishes a WebSocket communication channel (which we call "socket")
-3. _Client_ immediately dispatches a `ConnectionInit` message setting the `connectionParams` according to the server implementation
-4. _Server_ validates the connection initialisation request and dispatches a `ConnectionAck` message to the client on successful connection
-5. _Client_ has received the acknowledgement message and is now ready to request subscription operations
+1. _Server_ accepts the handshake and establishes a WebSocket communication channel (which we call "socket")
+1. _Client_ immediately dispatches a `ConnectionInit` message setting the `connectionParams` according to the server implementation
+1. _Server_ validates the connection initialisation request and dispatches a `ConnectionAck` message to the client on successful connection
+1. _Client_ has received the acknowledgement message and is now ready to request subscription operations
 
 ### Forbidden connection initialisation
 
 1. _Client_ sends a WebSocket handshake request with the sub-protocol: `graphql-subscriptions-ws`
-2. _Server_ accepts the handshake and establishes a WebSocket communication channel (which we call "socket")
-3. _Client_ immediately dispatches a `ConnectionInit` message setting the `connectionParams` according to the server implementation
-4. _Server_ validates the connection initialisation request and decides that the client is not allowed to establish a connection
-5. _Server_ terminates the socket by dispatching the close event `4403: Forbidden`
-6. _Client_ reports an error using the close event reason (which is `Forbidden`).
+1. _Server_ accepts the handshake and establishes a WebSocket communication channel (which we call "socket")
+1. _Client_ immediately dispatches a `ConnectionInit` message setting the `connectionParams` according to the server implementation
+1. _Server_ validates the connection initialisation request and decides that the client is not allowed to establish a connection
+1. _Server_ terminates the socket by dispatching the close event `4403: Forbidden`
+1. _Client_ reports an error using the close event reason (which is `Forbidden`)
 
 ### Erroneous connection initialisation
 
 1. _Client_ sends a WebSocket handshake request with the sub-protocol: `graphql-subscriptions-ws`
-2. _Server_ accepts the handshake and establishes a WebSocket communication channel (which we call "socket")
-3. _Client_ immediately dispatches a `ConnectionInit` message setting the `connectionParams` according to the server implementation
-4. _Server_ tries validating the connection initialisation request but an error `I'm a teapot` is thrown
-5. _Server_ terminates the socket by dispatching the close event `4400: I'm a teapot`
-6. _Client_ reports an error using the close event reason (which is `I'm a teapot`).
+1. _Server_ accepts the handshake and establishes a WebSocket communication channel (which we call "socket")
+1. _Client_ immediately dispatches a `ConnectionInit` message setting the `connectionParams` according to the server implementation
+1. _Server_ tries validating the connection initialisation request but an error `I'm a teapot` is thrown
+1. _Server_ terminates the socket by dispatching the close event `4400: I'm a teapot`
+1. _Client_ reports an error using the close event reason (which is `I'm a teapot`)
 
 ### Connection initialisation timeout
 
 1. _Client_ sends a WebSocket handshake request with the sub-protocol: `graphql-subscriptions-ws`
-2. _Server_ accepts the handshake and establishes a WebSocket communication channel (which we call "socket")
-3. _Client_ does not dispatch a `ConnectionInit` message
-4. _Server_ waits for the `ConnectionInit` message for the duration specified in the `connectionInitWaitTimeout` parameter
-5. _Server_ waiting time has passed
-6. _Server_ terminates the socket by dispatching the close event `4408: Connection initialisation timeout`
-7. _Client_ reports an error using the close event reason (which is `Connection initialisation timeout`).
+1. _Server_ accepts the handshake and establishes a WebSocket communication channel (which we call "socket")
+1. _Client_ does not dispatch a `ConnectionInit` message
+1. _Server_ waits for the `ConnectionInit` message for the duration specified in the `connectionInitWaitTimeout` parameter
+1. _Server_ waiting time has passed
+1. _Server_ terminates the socket by dispatching the close event `4408: Connection initialisation timeout`
+1. _Client_ reports an error using the close event reason (which is `Connection initialisation timeout`)
 
 ### Subscribe operation
 
 _The client and the server has already gone through [successful connection initialisation](#successful-connection-initialisation)._
 
 1. _Client_ generates a unique ID for the following operation
-2. _Client_ dispatches the `Subscribe` message with the, previously generated, unique ID through the `id` field and the requested subscription operation passed through the `payload` field
-3. _Server_ validates the request through the `onSubscribe` callback and accepts it
-4. _Server_ establishes a GraphQL subscription and listens for events in the source stream
-5. _Server_ dispatches `Next` messages for every event in the underlying subscription source stream matching the client's unique ID
-6. _Client_ stops the subscription by dispatching a `Complete` message with the matching unique ID
-7. _Server_ effectively stops the GraphQL subscription by completing/disposing the underlying source stream and cleaning up related resources
+1. _Client_ dispatches the `Subscribe` message with the, previously generated, unique ID through the `id` field and the requested subscription operation passed through the `payload` field
+1. _Server_ triggers the `onSubscribe` callback, if specified
+1. _Server_ validates the request and establishes a GraphQL subscription and listens for events in the source stream
+1. _Server_ dispatches `Next` messages for every event in the underlying subscription source stream matching the client's unique ID
+1. _Client_ stops the subscription by dispatching a `Complete` message with the matching unique ID
+1. _Server_ effectively stops the GraphQL subscription by completing/disposing the underlying source stream and cleaning up related resources
+1. _Server_ triggers the `onComplete` callback, if specified

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -98,13 +98,11 @@ Requests a subscription operation specified in the message `payload`. This messa
 interface SubscribeMessage {
   id: '<unique-operation-id>';
   type: 'subscribe';
-  payload: SubscribeOperation;
-}
-
-interface SubscribeOperation {
-  operationName: string;
-  query: string;
-  variables: Record<string, unknown>;
+  payload: {
+    operationName: string;
+    query: string;
+    variables: Record<string, unknown>;
+  };
 }
 ```
 
@@ -119,7 +117,7 @@ GraphQL subscription execution result message. It can be seen as an event in the
 ```typescript
 import { ExecutionResult } from 'graphql';
 
-interface DataMessage {
+interface NextMessage {
   id: '<unique-operation-id>';
   type: 'next';
   payload: ExecutionResult;
@@ -135,7 +133,7 @@ Subscription execution error triggered by the `Next` message happening before th
 ```typescript
 import { GraphQLError } from 'graphql';
 
-interface DataMessage {
+interface ErrorMessage {
   id: '<unique-operation-id>';
   type: 'error';
   payload: GraphQLError;
@@ -201,7 +199,7 @@ _The client and the server has already gone through [successful connection initi
 
 1. _Client_ generates a unique ID for the following operation
 1. _Client_ dispatches the `Subscribe` message with the, previously generated, unique ID through the `id` field and the requested subscription operation passed through the `payload` field
-1. _Server_ triggers the `onSubscribe` callback, if specified
+1. _Server_ triggers the `onSubscribe` callback, if specified, and uses the returned `SubscriptionArgs` for the operation
 1. _Server_ validates the request and establishes a GraphQL subscription and listens for events in the source stream
 1. _Server_ dispatches `Next` messages for every event in the underlying subscription source stream matching the client's unique ID
 1. _Client_ stops the subscription by dispatching a `Complete` message with the matching unique ID

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -120,7 +120,7 @@ interface ErrorMessage {
 
 Direction: **bidirectional**
 
-- **Server -> Client** (for `query` and `mutation` operations only) sent after the `Next` message, indicating that operation execution has completed. If the server dispatched the `Error` message relative to the original `Subscribe` message, **no `Complete` message will be emitted**.
+- **Server -> Client** indicates that the requested operation execution has completed. If the server dispatched the `Error` message relative to the original `Subscribe` message, **no `Complete` message will be emitted**.
 
 - **Client -> Server** (for `subscription` operations only) indicating that the client has stopped listening to the events and wants to complete the source stream. No further data events, relevant to the original subscription, should be sent through.
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -22,7 +22,7 @@ interface Message {
   id?: string;
   type: MessageType;
   payload?:
-    | Operation // Client -> Server
+    | SubscribeOperation // Client -> Server
     | ExecutionResult // Server -> Client
     | GraphQLError; // Server -> Client
 }
@@ -31,14 +31,13 @@ enum MessageType {
   ConnectionInit = 'connection_init', // Client -> Server
   ConnectionAck = 'connection_ack', // Server -> Client
 
-  Start = 'start', // Client -> Server
-  Data = 'data', // Server -> Client
+  Subscribe = 'subscribe', // Client -> Server
+  Next = 'next', // Server -> Client
   Error = 'error', // Server -> Client
-  Complete = 'complete', // Server -> Client
-  Stop = 'stop', // Client -> Server
+  Complete = 'complete', // Client -> Server
 }
 
-interface Operation {
+interface SubscribeOperation {
   operationName: string;
   query: string;
   variables: Record<string, unknown>;
@@ -55,7 +54,7 @@ Indicates that the client wants to initialise the connection with the server wit
 
 The client can specify additional `connectionParams` which are sent through the `payload` field in outgoing message.
 
-The server must receive the connection initialisation message within the allowed waiting time specified in the `connectionInitWaitTimeout` parameter during the server setup. If the client does not request a connection within the allowed timeout, the server will close the socket with the close event: `4408: Connection timeout`.
+The server must receive the connection initialisation message within the allowed waiting time specified in the `connectionInitWaitTimeout` parameter during the server setup. If the client does not request a connection within the allowed timeout, the server will close the socket with the close event: `4408: Connection initialisation timeout`.
 
 ```typescript
 interface ConnectionInitMessage {
@@ -84,40 +83,40 @@ interface ConnectionAckMessage {
 
 The client is now **ready** to request GraphQL operations.
 
-### `Start`
+### `Subscribe`
 
 Direction: **Client -> Server**
 
-Requests an execution of the operation specified in the message `payload`. This message leverages the unique ID field to connect future server messages to the operation started by this message.
+Requests a subscription operation specified in the message `payload`. This message leverages the unique ID field to connect future server messages to the operation started by this message.
 
 ```typescript
 interface StartMessage {
   id: '<unique-operation-id>';
-  type: 'start';
-  payload: Operation;
+  type: 'subscribe';
+  payload: SubscribeOperation;
 }
 
-interface Operation {
+interface SubscribeOperation {
   operationName: string;
   query: string;
   variables: Record<string, unknown>;
 }
 ```
 
-"Starting" an is allowed **only** after the server has acknowledged the connection through the `ConnectionAck` message, if the connection is not acknowledged/established, the socket will be closed immediately with a close event `4401: Unauthorized`.
+Subscribing an is allowed **only** after the server has acknowledged the connection through the `ConnectionAck` message, if the connection is not acknowledged/established, the socket will be closed immediately with a close event `4401: Unauthorized`.
 
-### `Data`
+### `Next`
 
 Direction: **Server -> Client**
 
-GraphQL execution result/data message requested through the `Start` message. It can be seen as a "response" to the `Start` message.
+GraphQL subscription execution result message. It can be seen as a data stream requested by the `Subscribe` message.
 
 ```typescript
 import { ExecutionResult } from 'graphql';
 
 interface DataMessage {
   id: '<unique-operation-id>';
-  type: 'data';
+  type: 'next';
   payload: ExecutionResult;
 }
 ```
@@ -126,7 +125,7 @@ interface DataMessage {
 
 Direction: **Server -> Client**
 
-GraphQL execution error caused by the `Start` message happening before the actual execution, usually due to validation errors.
+GraphQL subscription execution error caused by the `Next` message happening before the actual execution, usually due to validation errors.
 
 ```typescript
 import { GraphQLError } from 'graphql';
@@ -140,9 +139,9 @@ interface DataMessage {
 
 ### `Complete`
 
-Direction: **Server -> Client**
+Direction: **Client -> Server**
 
-Indicating that the GraphQL operation requested through the `Start` message has completed. No further `Data` will be sent through.
+Indicating that the client has stopped listening to the events and wants to complete the source stream. No further data events, relevant to the original operation, should be sent through.
 
 ```typescript
 interface CompleteMessage {
@@ -151,4 +150,54 @@ interface CompleteMessage {
 }
 ```
 
-If the server has emitted an `Error` connected to the operation, the complete message will not be sent. The `Error` prevents the operation from execution so the complete message is superfluous.
+## Examples
+
+For the sake of clarity, the following examples demonstrate the communication protocol.
+
+<h3 id="successful-connection-initialisation">Successful connection initialisation</h3>
+
+1. _Client_ sends a WebSocket handshake request with the sub-protocol: `graphql-subscriptions-ws`
+2. _Server_ accepts the handshake and establishes a WebSocket connection (which we call "socket")
+3. _Client_ immediately dispatches a `ConnectionInit` message setting the `connectionParams` according to the server implementation
+4. _Server_ validates the connection initialisation request and dispatches a `ConnectionAck` message to the client
+5. _Client_ has received the acknowledgement message and is now ready to request GraphQL operations
+
+### Forbidden connection initialisation
+
+1. _Client_ sends a WebSocket handshake request with the sub-protocol: `graphql-subscriptions-ws`
+2. _Server_ accepts the handshake and establishes a WebSocket connection (which we call "socket")
+3. _Client_ immediately dispatches a `ConnectionInit` message setting the `connectionParams` according to the server implementation
+4. _Server_ validates the connection initialisation request and decides that the client is not allowed to establish a connection
+5. _Server_ terminates the socket by dispatching the close event `4403: Forbidden`
+6. _Client_ reports an error using the close event reason (which is `Forbidden`).
+
+### Erroneous connection initialisation
+
+1. _Client_ sends a WebSocket handshake request with the sub-protocol: `graphql-subscriptions-ws`
+2. _Server_ accepts the handshake and establishes a WebSocket connection (which we call "socket")
+3. _Client_ immediately dispatches a `ConnectionInit` message setting the `connectionParams` according to the server implementation
+4. _Server_ tries validating the connection initialisation request but an error `I'm a teapot` is thrown
+5. _Server_ terminates the socket by dispatching the close event `4400: I'm a teapot`
+6. _Client_ reports an error using the close event reason (which is `I'm a teapot`).
+
+### Connection initialisation timeout
+
+1. _Client_ sends a WebSocket handshake request with the sub-protocol: `graphql-subscriptions-ws`
+2. _Server_ accepts the handshake and establishes a WebSocket connection (which we call "socket")
+3. _Client_ does not dispatch a `ConnectionInit` message
+4. _Server_ waits for the `ConnectionInit` message for the duration specified in the `connectionInitWaitTimeout` parameter
+5. _Server_ waiting time has passed
+6. _Server_ terminates the socket by dispatching the close event `4408: Connection initialisation timeout`
+7. _Client_ reports an error using the close event reason (which is `Connection initialisation timeout`).
+
+### Subscribe operation
+
+_The client and the server has already gone through [successful connection initialisation](#successful-connection-initialisation)._
+
+1. _Client_ generates a unique ID for the following operation
+2. _Client_ dispatches the `Start` message with the, previously generated, unique ID through the `id` field and the requested subscription operation passed through the `payload` field
+3. _Server_ validates the request through the `onSubscribe` callback and accepts it
+4. _Server_ establishes a GraphQL subscription and listens for events in the source stream
+5. _Server_ dispatches `Next` messages for every event in the underlying subscription source stream matching the client's unique ID
+6. _Client_ stops the subscription by dispatching a `Complete` message with the matching unique ID
+7. _Server_ effectively stops the GraphQL subscription by completing/disposing the underlying source stream and cleaning up related resources

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -77,7 +77,7 @@ interface SubscribeMessage {
 }
 ```
 
-Executing operations is allowed **only** after the server has acknowledged the connection through the `ConnectionAck` message, if the connection is not acknowledged/established, the socket will be terminated immediately with a close event `4401: Unauthorized`.
+Executing operations is allowed **only** after the server has acknowledged the connection through the `ConnectionAck` message, if the connection is not acknowledged, the socket will be terminated immediately with a close event `4401: Unauthorized`.
 
 ### `Next`
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -129,6 +129,12 @@ interface CompleteMessage {
 }
 ```
 
+### Invalid message
+
+Direction: **bidirectional**
+
+Receiving a message of a type or format which is not specified in this document will result in an **immediate** socket termination with a close event `4400: <error-message>`. The `<error-message>` can be vagouly descriptive on why the received message is invalid.
+
 ## Examples
 
 For the sake of clarity, the following examples demonstrate the communication protocol.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,5 +1,10 @@
 # GraphQL subscriptions over WebSocket Protocol
 
+## Nomenclature
+
+- **Socket** is the main WebSocket communication channel between the _server_ and the _client_
+- **Connection** is a connection **within the established socket** describing a "connection" through which the operation requests will be communicated
+
 ## Communication
 
 The WebSocket sub-protocol for this specification is: `graphql-subscriptions-ws`

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -104,7 +104,7 @@ interface NextMessage {
 
 Direction: **Server -> Client**
 
-Operation execution error triggered by the `Next` message happening before the actual execution, usually due to validation errors.
+Operation execution error(s) triggered by the `Next` message happening before the actual execution, usually due to validation errors.
 
 ```typescript
 import { GraphQLError } from 'graphql';
@@ -112,7 +112,7 @@ import { GraphQLError } from 'graphql';
 interface ErrorMessage {
   id: '<unique-operation-id>';
   type: 'error';
-  payload: GraphQLError;
+  payload: GraphQLError[];
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "files": [
     "lib",
     "README.md",
-    "LICENSE.md"
+    "LICENSE.md",
+    "PROTOCOL.md"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
# GraphQL over WebSocket Protocol

## Nomenclature

- **Socket** is the main WebSocket communication channel between the _server_ and the _client_
- **Connection** is a connection **within the established socket** describing a "connection" through which the operation requests will be communicated

## Communication

The WebSocket sub-protocol for this specification is: `graphql-transport-ws`

Messages are represented through the JSON structure and are stringified before being sent over the network. They are bidirectional, meaning both the server and the client conform to the specified message structure.

**All** messages contain the `type` field outlining the type or action this message describes. Depending on the type, the message can contain two more _optional_ fields:

- `id` used for uniquely identifying server responses and connecting them with the client requests
- `payload` holding the extra "payload" information to go with the specific message type

The server can terminate the socket (kick the client off) at any time. The close event dispatched by the server is used to describe the fatal error to the client.

The client terminates the socket and closes the connection by dispatching a `1000: Normal Closure` close event to the server indicating a normal closure.

## Message types

### `ConnectionInit`

Direction: **Client -> Server**

Indicates that the client wants to establish a connection within the existing socket. This connection is **not** the actual WebSocket communication channel, but is rather a frame within it asking the server to allow future subscription operation requests.

The client can specify additional `connectionParams` which are sent through the `payload` field in the outgoing message.

The server must receive the connection initialisation message within the allowed waiting time specified in the `connectionInitWaitTimeout` parameter during the server setup. If the client does not request a connection within the allowed timeout, the server will terminate the socket with the close event: `4408: Connection initialisation timeout`.

```typescript
interface ConnectionInitMessage {
  type: 'connection_init';
  payload?: Record<string, unknown>; // connectionParams
}
```

The server will respond by either:

- Dispatching a `ConnectionAck` message acknowledging that the connection has been successfully established. The server does not implement the `onConnect` callback or the implemented callback has returned `true`.
- Closing the socket with a close event `4403: Forbidden` indicating that the connection request has been denied because of access control. The server has returned `false` in the `onConnect` callback.
- Closing the socket with a close event `4400: <error-message>` indicating that the connection request has been denied because of an implementation specific error. The server has thrown an error in the `onConnect` callback, the thrown error's message is the `<error-message>` in the close event.

### `ConnectionAck`

Direction: **Server -> Client**

Potential response to the `ConnectionInit` message from the client acknowledging a successful connection with the server.

```typescript
interface ConnectionAckMessage {
  type: 'connection_ack';
}
```

The client is now **ready** to request subscription operations.

### `Subscribe`

Direction: **Client -> Server**

Requests a operation specified in the message `payload`. This message leverages the unique ID field to connect future server messages to the operation started by this message.

```typescript
import { DocumentNode } from 'graphql';

interface SubscribeMessage {
  id: '<unique-operation-id>';
  type: 'subscribe';
  payload: {
    operationName: string;
    query: string | DocumentNode;
    variables: Record<string, unknown>;
  };
}
```

Executing operations is allowed **only** after the server has acknowledged the connection through the `ConnectionAck` message, if the connection is not acknowledged, the socket will be terminated immediately with a close event `4401: Unauthorized`.

### `Next`

Direction: **Server -> Client**

Operation execution result message.

- If the operation is a `query` or `mutation`, the message can be seen as the final execution result. This message is followed by the `Complete` message indicating the completion of the operation.
- If the operation is a `subscription`, the message can be seen as an event in the source stream requested by the `Subscribe` message.

```typescript
import { ExecutionResult } from 'graphql';

interface NextMessage {
  id: '<unique-operation-id>';
  type: 'next';
  payload: ExecutionResult;
}
```

### `Error`

Direction: **Server -> Client**

Operation execution error(s) triggered by the `Next` message happening before the actual execution, usually due to validation errors.

```typescript
import { GraphQLError } from 'graphql';

interface ErrorMessage {
  id: '<unique-operation-id>';
  type: 'error';
  payload: GraphQLError[];
}
```

### `Complete`

Direction: **bidirectional**

- **Server -> Client** indicates that the requested operation execution has completed. If the server dispatched the `Error` message relative to the original `Subscribe` message, **no `Complete` message will be emitted**.

- **Client -> Server** (for `subscription` operations only) indicating that the client has stopped listening to the events and wants to complete the source stream. No further data events, relevant to the original subscription, should be sent through.

```typescript
interface CompleteMessage {
  id: '<unique-operation-id>';
  type: 'complete';
}
```

### Invalid message

Direction: **bidirectional**

Receiving a message of a type or format which is not specified in this document will result in an **immediate** socket termination with a close event `4400: <error-message>`. The `<error-message>` can be vagouly descriptive on why the received message is invalid.

## Examples

For the sake of clarity, the following examples demonstrate the communication protocol.

<h3 id="successful-connection-initialisation">Successful connection initialisation</h3>

1. _Client_ sends a WebSocket handshake request with the sub-protocol: `graphql-transport-ws`
1. _Server_ accepts the handshake and establishes a WebSocket communication channel (which we call "socket")
1. _Client_ immediately dispatches a `ConnectionInit` message setting the `connectionParams` according to the server implementation
1. _Server_ validates the connection initialisation request and dispatches a `ConnectionAck` message to the client on successful connection
1. _Client_ has received the acknowledgement message and is now ready to request operation executions

### Forbidden connection initialisation

1. _Client_ sends a WebSocket handshake request with the sub-protocol: `graphql-transport-ws`
1. _Server_ accepts the handshake and establishes a WebSocket communication channel (which we call "socket")
1. _Client_ immediately dispatches a `ConnectionInit` message setting the `connectionParams` according to the server implementation
1. _Server_ validates the connection initialisation request and decides that the client is not allowed to establish a connection
1. _Server_ terminates the socket by dispatching the close event `4403: Forbidden`
1. _Client_ reports an error using the close event reason (which is `Forbidden`)

### Erroneous connection initialisation

1. _Client_ sends a WebSocket handshake request with the sub-protocol: `graphql-transport-ws`
1. _Server_ accepts the handshake and establishes a WebSocket communication channel (which we call "socket")
1. _Client_ immediately dispatches a `ConnectionInit` message setting the `connectionParams` according to the server implementation
1. _Server_ tries validating the connection initialisation request but an error `I'm a teapot` is thrown
1. _Server_ terminates the socket by dispatching the close event `4400: I'm a teapot`
1. _Client_ reports an error using the close event reason (which is `I'm a teapot`)

### Connection initialisation timeout

1. _Client_ sends a WebSocket handshake request with the sub-protocol: `graphql-transport-ws`
1. _Server_ accepts the handshake and establishes a WebSocket communication channel (which we call "socket")
1. _Client_ does not dispatch a `ConnectionInit` message
1. _Server_ waits for the `ConnectionInit` message for the duration specified in the `connectionInitWaitTimeout` parameter
1. _Server_ waiting time has passed
1. _Server_ terminates the socket by dispatching the close event `4408: Connection initialisation timeout`
1. _Client_ reports an error using the close event reason (which is `Connection initialisation timeout`)

### Query/Mutation operation

_The client and the server has already gone through [successful connection initialisation](#successful-connection-initialisation)._

1. _Client_ generates a unique ID for the following operation
1. _Client_ dispatches the `Subscribe` message with the, previously generated, unique ID through the `id` field and the requested `query`/`mutation` operation passed through the `payload` field
1. _Server_ triggers the `onSubscribe` callback, if specified, and uses the returned `ExecutionArgs` for the operation
1. _Server_ validates the request and executes the GraphQL operation
1. _Server_ dispatches a `Next` message with the execution result matching the client's unique ID
1. _Server_ dispatches the `Complete` message with the matching unique ID indicating that the execution has completed
1. _Server_ triggers the `onComplete` callback, if specified

### Subscribe operation

_The client and the server has already gone through [successful connection initialisation](#successful-connection-initialisation)._

1. _Client_ generates a unique ID for the following operation
1. _Client_ dispatches the `Subscribe` message with the, previously generated, unique ID through the `id` field and the requested subscription operation passed through the `payload` field
1. _Server_ triggers the `onSubscribe` callback, if specified, and uses the returned `ExecutionArgs` for the operation
1. _Server_ validates the request, establishes a GraphQL subscription and listens for events in the source stream
1. _Server_ dispatches `Next` messages for every event in the underlying subscription source stream matching the client's unique ID
1. _Client_ stops the subscription by dispatching a `Complete` message with the matching unique ID
1. _Server_ effectively stops the GraphQL subscription by completing/disposing the underlying source stream and cleaning up related resources
1. _Server_ triggers the `onComplete` callback, if specified
