### PR TITLE
feat: WebSocket Ping and Pong as keep-alive

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -20,6 +20,14 @@ The server can terminate the socket (kick the client off) at any time. The close
 
 The client terminates the socket and closes the connection by dispatching a `1000: Normal Closure` close event to the server indicating a normal closure.
 
+## Keep-Alive
+
+The server will occasionally check if the client is still "alive", available and listening. In order to perform this check, implementation leverages the standardized [Pings and Pongs: The Heartbeat of WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#Pings_and_Pongs_The_Heartbeat_of_WebSockets).
+
+Keep-Alive interval and the "pong wait" timeout can be tuned by using the accompanying configuration parameter on the server.
+
+Ping and Pong feature is a mandatory requirement by [The WebSocket Protocol](https://tools.ietf.org/html/rfc6455#section-5.5.2). All clients that don't support it are **not** RFC6455 compliant and will simply have their socket terminated after the pong wait has passed.
+
 ## Message types
 
 ### `ConnectionInit`

--- a/src/server.ts
+++ b/src/server.ts
@@ -136,6 +136,15 @@ export interface ServerOptions {
    * has been closed.
    */
   onComplete?: (ctx: Context, message: CompleteMessage) => void;
+  /**
+   * The timout between dispatched keep-alive messages. Internally the lib
+   * uses the [WebSocket Ping and Pongs]((https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#Pings_and_Pongs_The_Heartbeat_of_WebSockets)) to check that the link between
+   * the clients and the server is operating and to prevent the link from being broken due to idling.
+   * Set to nullish value to disable.
+   *
+   * @default 12 * 1000 (12 seconds)
+   */
+  keepAlive?: number;
 }
 
 export interface Context {
@@ -197,6 +206,7 @@ export function createServer(
     formatExecutionResult,
     onSubscribe,
     onComplete,
+    keepAlive = 12 * 1000, // 12 seconds
   } = options;
   const webSocketServer = isWebSocketServer(websocketOptionsOrServer)
     ? websocketOptionsOrServer
@@ -238,11 +248,41 @@ export function createServer(
         }
       }, connectionInitWaitTimeout);
 
+    // keep alive through ping-pong messages
+    // read more about the websocket heartbeat here: https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#Pings_and_Pongs_The_Heartbeat_of_WebSockets
+    let pongWait: NodeJS.Timeout | null;
+    const pingInterval =
+      keepAlive && // even 0 disables it
+      keepAlive !== Infinity &&
+      setInterval(() => {
+        // terminate the connection after pong wait has passed because the client is idle
+        pongWait = setTimeout(() => {
+          socket.terminate();
+        }, keepAlive);
+
+        // listen for client's pong and stop socket termination
+        socket.once('pong', () => {
+          if (pongWait) {
+            clearTimeout(pongWait);
+            pongWait = null;
+          }
+        });
+
+        // issue a ping to the client
+        socket.ping();
+      }, keepAlive);
+
     function errorOrCloseHandler(
       errorOrClose: WebSocket.ErrorEvent | WebSocket.CloseEvent,
     ) {
       if (connectionInitWait) {
         clearTimeout(connectionInitWait);
+      }
+      if (pongWait) {
+        clearTimeout(pongWait);
+      }
+      if (pingInterval) {
+        clearInterval(pingInterval);
       }
 
       if (isErrorEvent(errorOrClose)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -255,21 +255,24 @@ export function createServer(
       keepAlive && // even 0 disables it
       keepAlive !== Infinity &&
       setInterval(() => {
-        // terminate the connection after pong wait has passed because the client is idle
-        pongWait = setTimeout(() => {
-          socket.terminate();
-        }, keepAlive);
+        // ping pong on open sockets only
+        if (socket.readyState === WebSocket.OPEN) {
+          // terminate the connection after pong wait has passed because the client is idle
+          pongWait = setTimeout(() => {
+            socket.terminate();
+          }, keepAlive);
 
-        // listen for client's pong and stop socket termination
-        socket.once('pong', () => {
-          if (pongWait) {
-            clearTimeout(pongWait);
-            pongWait = null;
-          }
-        });
+          // listen for client's pong and stop socket termination
+          socket.once('pong', () => {
+            if (pongWait) {
+              clearTimeout(pongWait);
+              pongWait = null;
+            }
+          });
 
-        // issue a ping to the client
-        socket.ping();
+          // issue a ping to the client
+          socket.ping();
+        }
       }, keepAlive);
 
     function errorOrCloseHandler(


### PR DESCRIPTION
Closes: #10 

Implemented server-side pinging **only**. Pong messages are automatically sent in response to ping messages as required by the spec, meaning - this feature is a mandatory built-in, all browsers that don't support Ping and Pong are not RFC6455 compliant.

On the side note, there is no way to detect if Ping and Pong is supported through browser's JavaScript. Incompatible browsers will simply be kicked out after the keep-alive timeout.