### PR TITLE
feat(server): Support returning multiple results from `execute`

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -74,10 +74,8 @@ export interface ServerOptions {
     >;
   };
   /**
-   * Is the `subscribe` function
-   * from GraphQL which is used to
-   * execute the subscription operation
-   * upon.
+   * Is the `execute` function from GraphQL which is
+   * used to execute the query/mutation operation.
    */
   execute: (
     args: ExecutionArgs,
@@ -86,10 +84,8 @@ export interface ServerOptions {
     | AsyncIterableIterator<ExecutionResult>
     | ExecutionResult;
   /**
-   * Is the `subscribe` function
-   * from GraphQL which is used to
-   * execute the subscription operation
-   * upon.
+   * Is the `subscribe` function from GraphQL which is
+   * used to execute the subscription operation.
    */
   subscribe: (
     args: ExecutionArgs,

--- a/src/server.ts
+++ b/src/server.ts
@@ -82,9 +82,9 @@ export interface ServerOptions {
   execute: (
     args: ExecutionArgs,
   ) =>
-    | Promise<ExecutionResult>
-    | ExecutionResult
-    | AsyncIterableIterator<ExecutionResult>;
+    | Promise<AsyncIterableIterator<ExecutionResult> | ExecutionResult>
+    | AsyncIterableIterator<ExecutionResult>
+    | ExecutionResult;
   /**
    * Is the `subscribe` function
    * from GraphQL which is used to

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -559,6 +559,87 @@ describe('Subscribe', () => {
     await wait(20);
   });
 
+  it('should execute a query operation with custom execute that returns a AsyncIterableIterator, "next" the results and then "complete"', async () => {
+    expect.assertions(5);
+
+    await makeServer({
+      schema,
+      execute: async function* () {
+        for (const value of ['Hi', 'Hello', 'Sup']) {
+          yield {
+            data: {
+              getValue: value,
+            },
+          };
+        }
+      },
+    });
+
+    const client = new WebSocket(url, GRAPHQL_TRANSPORT_WS_PROTOCOL);
+    client.onopen = () => {
+      client.send(
+        stringifyMessage<MessageType.ConnectionInit>({
+          type: MessageType.ConnectionInit,
+        }),
+      );
+    };
+
+    let receivedNextCount = 0;
+    client.onmessage = ({ data }) => {
+      const message = parseMessage(data);
+      switch (message.type) {
+        case MessageType.ConnectionAck:
+          client.send(
+            stringifyMessage<MessageType.Subscribe>({
+              id: '1',
+              type: MessageType.Subscribe,
+              payload: {
+                operationName: 'TestString',
+                query: `query TestString {
+                  getValue
+                }`,
+                variables: {},
+              },
+            }),
+          );
+          break;
+        case MessageType.Next:
+          receivedNextCount++;
+          if (receivedNextCount === 1) {
+            expect(message).toEqual({
+              id: '1',
+              type: MessageType.Next,
+              payload: { data: { getValue: 'Hi' } },
+            });
+          } else if (receivedNextCount === 2) {
+            expect(message).toEqual({
+              id: '1',
+              type: MessageType.Next,
+              payload: { data: { getValue: 'Hello' } },
+            });
+          } else if (receivedNextCount === 3) {
+            expect(message).toEqual({
+              id: '1',
+              type: MessageType.Next,
+              payload: { data: { getValue: 'Sup' } },
+            });
+          }
+          break;
+        case MessageType.Complete:
+          expect(receivedNextCount).toEqual(3);
+          expect(message).toEqual({
+            id: '1',
+            type: MessageType.Complete,
+          });
+          break;
+        default:
+          fail(`Not supposed to receive a message of type ${message.type}`);
+      }
+    };
+
+    await wait(20);
+  });
+
   it('should execute the query of `DocumentNode` type, "next" the result and then "complete"', async () => {
     expect.assertions(3);
 

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -559,7 +559,7 @@ describe('Subscribe', () => {
     await wait(20);
   });
 
-  it('should execute a query operation with custom execute that returns a AsyncIterableIterator, "next" the results and then "complete"', async () => {
+  it('should execute the live query, "next" multiple results and then "complete"', async () => {
     expect.assertions(5);
 
     await makeServer({


### PR DESCRIPTION
This PR adds supporting the changes of https://github.com/graphql/graphql-js/pull/2319 ([but also for allowing to use graphql-transport-ws with my live query implementation](https://github.com/n1ru4l/graphql-live-queries/blob/a4ce5ac727a7c44fd205b824d678db7717abd220/packages/in-memory-live-query-store/src/InMemoryLiveQueryStore.ts#L96-L103))

@enisdenjo Please let me know your opinion on adding this 😄 