### PR TITLE
fix(tests): Avoid relying on setTimeout where possible.

### DIFF
--- a/src/tests/fixtures/deferred.ts
+++ b/src/tests/fixtures/deferred.ts
@@ -1,0 +1,25 @@
+type Deferred<T = void> = {
+  resolve: (input: T) => void;
+  reject: (input: unknown) => void;
+  promise: Promise<T>;
+  status: 'pending' | 'resolved' | 'rejected';
+};
+
+export const createDeferred = <T = void>(): Deferred<T> => {
+  let d = {} as Deferred<T>;
+  const promise = new Promise<T>((resolve, reject) => {
+    d = {
+      status: 'pending',
+      resolve: (arg: T) => {
+        d.status = 'resolved';
+        resolve(arg);
+      },
+      reject: (reason?: unknown) => {
+        d.status = 'rejected';
+        reject(reason);
+      },
+    } as Deferred<T>;
+  });
+  d.promise = promise;
+  return d as Deferred<T>;
+};

--- a/src/tests/fixtures/simple.ts
+++ b/src/tests/fixtures/simple.ts
@@ -86,7 +86,7 @@ export async function startServer(
     res.end();
   });
 
-  const server = await createServer(
+  const server = createServer(
     {
       schema,
       execute,


### PR DESCRIPTION
This PR attempts to solve https://github.com/enisdenjo/graphql-transport-ws/issues/29 for the server test suite.