### PR TITLE
refactor(server): Stabilize and simplify tests

### DIFF
--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -59,8 +59,6 @@ class Client extends WebSocket {
  */
 
 it('should allow connections with valid protocols only', async () => {
-  expect.assertions(10);
-
   await makeServer();
 
   let client = new Client('');

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -127,7 +127,7 @@ it('should allow connections with valid protocols only', async () => {
   client = await createTClient(GRAPHQL_TRANSPORT_WS_PROTOCOL);
   await client.waitForClose(
     () => fail('shouldnt close for valid protocol'),
-    100, // should be kicked off within this time
+    30, // should be kicked off within this time
   );
 });
 
@@ -449,7 +449,7 @@ describe('Connect', () => {
 
     await client.waitForClose(() => {
       fail('Shouldnt have closed');
-    }, 100);
+    }, 30);
   });
 
   it('should close the socket if an additional `ConnectionInit` message is received while one is pending', async () => {
@@ -622,7 +622,7 @@ describe('Subscribe', () => {
 
     await client.waitForClose(() => {
       fail('Shouldt have closed');
-    }, 100);
+    }, 30);
   });
 
   it('should execute the query of `string` type, "next" the result and then "complete"', async () => {
@@ -844,7 +844,7 @@ describe('Subscribe', () => {
 
     await client.waitForClose(() => {
       fail('Shouldnt close because of GraphQL errors');
-    }, 100);
+    }, 30);
   });
 
   it('should execute the subscription and "next" the published payload', async () => {
@@ -969,7 +969,7 @@ describe('Subscribe', () => {
 
     await client.waitForClose(() => {
       fail('Shouldnt have received a message');
-    }, 100);
+    }, 30);
   });
 
   it('should close the socket on duplicate `subscription` operation subscriptions request', async () => {

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -36,7 +36,7 @@ function createTClient(
   let closeEvent: WebSocket.CloseEvent;
   const queue: WebSocket.MessageEvent[] = [];
   return new Promise<{
-    send: (data?: unknown) => void;
+    ws: WebSocket;
     waitForMessage: (
       test: (data: WebSocket.MessageEvent) => void,
       expire?: number,
@@ -51,7 +51,7 @@ function createTClient(
     ws.onmessage = (message) => queue.push(message); // guarantee message delivery with a queue
     ws.once('open', () =>
       resolve({
-        send: (data) => ws.send(data),
+        ws,
         async waitForMessage(test, expire) {
           return new Promise((resolve) => {
             const done = () => {
@@ -180,7 +180,7 @@ describe('Connect', () => {
 
     const client = await createTClient();
 
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -203,7 +203,7 @@ describe('Connect', () => {
     });
 
     const client = await createTClient();
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -219,7 +219,7 @@ describe('Connect', () => {
   it('should acknowledge connection if not implemented or returning `true`', async () => {
     async function test() {
       const client = await createTClient();
-      client.send(
+      client.ws.send(
         stringifyMessage<MessageType.ConnectionInit>({
           type: MessageType.ConnectionInit,
         }),
@@ -262,7 +262,7 @@ describe('Connect', () => {
       },
     });
 
-    (await createTClient()).send(
+    (await createTClient()).ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
         payload: connectionParams,
@@ -289,7 +289,7 @@ describe('Connect', () => {
 
     const client = await createTClient();
 
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -313,7 +313,7 @@ describe('Connect', () => {
 
     const client = await createTClient();
 
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -321,7 +321,7 @@ describe('Connect', () => {
 
     // issue an additional one a bit later
     setTimeout(() => {
-      client.send(
+      client.ws.send(
         stringifyMessage<MessageType.ConnectionInit>({
           type: MessageType.ConnectionInit,
         }),
@@ -340,7 +340,7 @@ describe('Connect', () => {
 
     const client = await createTClient();
 
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -351,7 +351,7 @@ describe('Connect', () => {
     });
 
     // random connection init message even after acknowledgement
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -371,7 +371,7 @@ describe('Subscribe', () => {
 
     const client = await createTClient();
 
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.Subscribe>({
         id: '1',
         type: MessageType.Subscribe,
@@ -397,7 +397,7 @@ describe('Subscribe', () => {
 
     const client = await createTClient();
 
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -407,7 +407,7 @@ describe('Subscribe', () => {
       const message = parseMessage(data);
       switch (message.type) {
         case MessageType.ConnectionAck:
-          client.send(
+          client.ws.send(
             stringifyMessage<MessageType.Subscribe>({
               id: '1',
               type: MessageType.Subscribe,
@@ -448,7 +448,7 @@ describe('Subscribe', () => {
 
     const client = await createTClient();
 
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -457,7 +457,7 @@ describe('Subscribe', () => {
     await client.waitForMessage(({ data }) => {
       const message = parseMessage(data);
       if (message.type === MessageType.ConnectionAck) {
-        client.send(
+        client.ws.send(
           stringifyMessage<MessageType.Subscribe>({
             id: '1',
             type: MessageType.Subscribe,
@@ -494,7 +494,7 @@ describe('Subscribe', () => {
     });
 
     const client = await createTClient();
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -503,7 +503,7 @@ describe('Subscribe', () => {
     await client.waitForMessage(({ data }) => {
       const message = parseMessage(data);
       if (message.type === MessageType.ConnectionAck) {
-        client.send(
+        client.ws.send(
           stringifyMessage<MessageType.Subscribe>({
             id: '1',
             type: MessageType.Subscribe,
@@ -552,7 +552,7 @@ describe('Subscribe', () => {
     });
 
     const client = await createTClient();
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -561,7 +561,7 @@ describe('Subscribe', () => {
     await client.waitForMessage(({ data }) => {
       const message = parseMessage(data);
       if (message.type === MessageType.ConnectionAck) {
-        client.send(
+        client.ws.send(
           stringifyMessage<MessageType.Subscribe>({
             id: '1',
             type: MessageType.Subscribe,
@@ -617,7 +617,7 @@ describe('Subscribe', () => {
     });
 
     const client = await createTClient();
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -626,7 +626,7 @@ describe('Subscribe', () => {
     await client.waitForMessage(({ data }) => {
       const message = parseMessage(data);
       if (message.type === MessageType.ConnectionAck) {
-        client.send(
+        client.ws.send(
           stringifyMessage<MessageType.Subscribe>({
             id: '1',
             type: MessageType.Subscribe,
@@ -666,7 +666,7 @@ describe('Subscribe', () => {
     });
 
     const client = await createTClient();
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -675,7 +675,7 @@ describe('Subscribe', () => {
     await client.waitForMessage(({ data }) => {
       const message = parseMessage(data);
       if (message.type === MessageType.ConnectionAck) {
-        client.send(
+        client.ws.send(
           stringifyMessage<MessageType.Subscribe>({
             id: '1',
             type: MessageType.Subscribe,
@@ -732,7 +732,7 @@ describe('Subscribe', () => {
     });
 
     const client = await createTClient();
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -741,7 +741,7 @@ describe('Subscribe', () => {
     await client.waitForMessage(({ data }) => {
       const message = parseMessage(data);
       if (message.type === MessageType.ConnectionAck) {
-        client.send(
+        client.ws.send(
           stringifyMessage<MessageType.Subscribe>({
             id: '1',
             type: MessageType.Subscribe,
@@ -783,7 +783,7 @@ describe('Subscribe', () => {
     });
 
     const client = await createTClient();
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -792,7 +792,7 @@ describe('Subscribe', () => {
     await client.waitForMessage(({ data }) => {
       const message = parseMessage(data);
       if (message.type === MessageType.ConnectionAck) {
-        client.send(
+        client.ws.send(
           stringifyMessage<MessageType.Subscribe>({
             id: '1',
             type: MessageType.Subscribe,
@@ -827,7 +827,7 @@ describe('Subscribe', () => {
     });
 
     // complete
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.Complete>({
         id: '1',
         type: MessageType.Complete,
@@ -864,7 +864,7 @@ describe('Subscribe', () => {
     await makeServer();
 
     const client = await createTClient();
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.ConnectionInit>({
         type: MessageType.ConnectionInit,
       }),
@@ -873,7 +873,7 @@ describe('Subscribe', () => {
     await client.waitForMessage(({ data }) => {
       const message = parseMessage(data);
       if (message.type === MessageType.ConnectionAck) {
-        client.send(
+        client.ws.send(
           stringifyMessage<MessageType.Subscribe>({
             id: 'not-unique',
             type: MessageType.Subscribe,
@@ -892,7 +892,7 @@ describe('Subscribe', () => {
     });
 
     // try subscribing with a live subscription id
-    client.send(
+    client.ws.send(
       stringifyMessage<MessageType.Subscribe>({
         id: 'not-unique',
         type: MessageType.Subscribe,
@@ -913,26 +913,19 @@ describe('Subscribe', () => {
 });
 
 describe('Keep-Alive', () => {
-  it('should dispatch pings after the timeout has passed', async () => {
+  it('should dispatch pings after the timeout has passed', async (done) => {
     await makeServer({
       keepAlive: 50,
     });
 
-    const client = new WebSocket(url, GRAPHQL_TRANSPORT_WS_PROTOCOL);
-    client.onopen = () => {
-      client.send(
-        stringifyMessage<MessageType.ConnectionInit>({
-          type: MessageType.ConnectionInit,
-        }),
-      );
-    };
-    await wait(10);
+    const client = await createTClient();
+    client.ws.send(
+      stringifyMessage<MessageType.ConnectionInit>({
+        type: MessageType.ConnectionInit,
+      }),
+    );
 
-    const onPingFn = jest.fn();
-    client.once('ping', onPingFn);
-    await wait(50);
-
-    expect(onPingFn).toBeCalled();
+    client.ws.once('ping', () => done());
   });
 
   it('should not dispatch pings if disabled with nullish timeout', async () => {
@@ -940,59 +933,43 @@ describe('Keep-Alive', () => {
       keepAlive: 0,
     });
 
-    const client = new WebSocket(url, GRAPHQL_TRANSPORT_WS_PROTOCOL);
-    client.onopen = () => {
-      client.send(
-        stringifyMessage<MessageType.ConnectionInit>({
-          type: MessageType.ConnectionInit,
-        }),
-      );
-    };
-    await wait(10);
+    const client = await createTClient();
+    client.ws.send(
+      stringifyMessage<MessageType.ConnectionInit>({
+        type: MessageType.ConnectionInit,
+      }),
+    );
 
-    const onPingFn = jest.fn();
-    client.once('ping', onPingFn);
-    await wait(50);
+    client.ws.once('ping', () => fail('Shouldnt have pinged'));
 
-    expect(onPingFn).not.toBeCalled();
+    await wait(100);
   });
 
   it('should terminate the socket if no pong is sent in response to a ping', async () => {
-    expect.assertions(4);
-
     await makeServer({
       keepAlive: 50,
     });
 
-    const client = new WebSocket(url, GRAPHQL_TRANSPORT_WS_PROTOCOL);
-    client.onopen = () => {
-      client.send(
-        stringifyMessage<MessageType.ConnectionInit>({
-          type: MessageType.ConnectionInit,
-        }),
-      );
-    };
-    await wait(10);
+    const client = await createTClient();
+    client.ws.send(
+      stringifyMessage<MessageType.ConnectionInit>({
+        type: MessageType.ConnectionInit,
+      }),
+    );
 
     // disable pong
-    client.pong = () => {
+    client.ws.pong = () => {
       /**/
     };
-    client.onclose = (event) => {
-      // termination is not graceful or clean
+
+    // ping is received
+    await new Promise((resolve) => client.ws.once('ping', resolve));
+
+    // termination is not graceful or clean
+    await client.waitForClose((event) => {
       expect(event.code).toBe(1006);
       expect(event.wasClean).toBeFalsy();
-    };
-
-    const onPingFn = jest.fn();
-    client.once('ping', onPingFn);
-    await wait(50);
-
-    expect(onPingFn).toBeCalled(); // ping is received
-
-    await wait(50 + 10); // wait for the timeout to pass and termination to settle
-
-    expect(client.readyState).toBe(WebSocket.CLOSED);
+    });
   });
 });
 

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -51,7 +51,14 @@ function createTClient(
       resolve({
         send: (data) => ws.send(data),
         async waitForMessage(test) {
-          ws.onmessage = (event) => test(event);
+          return new Promise((resolve) => {
+            ws.onmessage = (event) => {
+              // @ts-expect-error: its ok
+              ws.onmessage = null;
+              test(event);
+              resolve();
+            };
+          });
         },
         async waitForClose(
           test?: (event: WebSocket.CloseEvent) => void,

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -4,10 +4,6 @@ import { GRAPHQL_TRANSPORT_WS_PROTOCOL } from '../protocol';
 import { MessageType, parseMessage, stringifyMessage } from '../message';
 import { startServer, url, schema, pubsub } from './fixtures/simple';
 
-/** Waits for the specified timeout and then resolves the promise. */
-const wait = (timeout: number) =>
-  new Promise((resolve) => setTimeout(resolve, timeout));
-
 let forgottenDispose: (() => Promise<void>) | undefined;
 async function makeServer(
   ...args: Parameters<typeof startServer>
@@ -950,7 +946,6 @@ describe('Subscribe', () => {
         type: MessageType.Complete,
       }),
     );
-    await wait(10);
 
     // confirm complete
     await client.waitForMessage(({ data }) => {
@@ -1041,7 +1036,7 @@ describe('Keep-Alive', () => {
     client.ws.once('ping', () => done());
   });
 
-  it('should not dispatch pings if disabled with nullish timeout', async () => {
+  it('should not dispatch pings if disabled with nullish timeout', async (done) => {
     await makeServer({
       keepAlive: 0,
     });
@@ -1055,7 +1050,7 @@ describe('Keep-Alive', () => {
 
     client.ws.once('ping', () => fail('Shouldnt have pinged'));
 
-    await wait(100);
+    setTimeout(done, 50);
   });
 
   it('should terminate the socket if no pong is sent in response to a ping', async () => {

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -36,14 +36,16 @@ class Client extends WebSocket {
 
   public async waitForClose(
     test?: (event: WebSocket.CloseEvent) => void,
-    expire = 3000,
+    expire?: number,
   ) {
     return new Promise((resolve) => {
-      setTimeout(() => {
-        // @ts-expect-error: its ok
-        this.onclose = null; // expired
-        resolve();
-      }, expire);
+      if (expire) {
+        setTimeout(() => {
+          // @ts-expect-error: its ok
+          this.onclose = null; // expired
+          resolve();
+        }, expire);
+      }
       this.onclose = (event) => {
         if (test) test(event);
         resolve();

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -63,13 +63,13 @@ function createTClient(
             if (queue.length > 0) {
               return done();
             }
+            ws.once('message', done);
             if (expire) {
               setTimeout(() => {
                 ws.removeListener('message', done); // expired
                 resolve();
               }, expire);
             }
-            ws.once('message', done);
           });
         },
         async waitForClose(
@@ -81,6 +81,11 @@ function createTClient(
               if (test) test(closeEvent);
               return resolve();
             }
+            ws.onclose = (event) => {
+              closeEvent = event;
+              if (test) test(event);
+              resolve();
+            };
             if (expire) {
               setTimeout(() => {
                 // @ts-expect-error: its ok
@@ -88,11 +93,6 @@ function createTClient(
                 resolve();
               }, expire);
             }
-            ws.onclose = (event) => {
-              closeEvent = event;
-              if (test) test(event);
-              resolve();
-            };
           });
         },
       }),

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -848,8 +848,14 @@ describe('Subscribe', () => {
   });
 
   it('should execute the subscription and "next" the published payload', async () => {
-    await makeServer({
+    let onSubscribe: () => void;
+    makeServer({
       schema,
+      subscribe: async (args) => {
+        const subscription = await subscribe(args);
+        onSubscribe(); // test will fail if `onSubscribe` is not set yet
+        return subscription;
+      },
     });
 
     const client = await createTClient();
@@ -876,7 +882,9 @@ describe('Subscribe', () => {
         }),
       );
     });
+    await new Promise((resolve) => (onSubscribe = resolve));
 
+    // 👇 comment out the `setTimeout` to see the test fail
     setTimeout(() => {
       pubsub.publish('becameHappy', {
         becameHappy: {


### PR DESCRIPTION
Closes #29, closes #32

A few takeaways:
- Guaranteed shutdown of the server between tests. I've been naively simply using the `server.close()` function which actually [stops the server from accepting new connections and keeps existing connections](https://nodejs.org/api/net.html#net_server_close_callback)
- Super simple testing client