### PR TITLE
fix: yarn engine is not required

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=12",
-    "yarn": ">=1.22.4"
+    "node": ">=12"
   },
   "scripts": {
     "gendocs": "typedoc --options typedoc.js src/",


### PR DESCRIPTION
I don't think we need to make sure the user is using a specific version of yarn

this was causing some trouble for us