### PR TITLE
feat(server): More callbacks, clearer differences and higher extensibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,13 +544,9 @@ createServer(
       };
 
       // dont forget to validate when returning custom execution args!
-      const validationErrors = validate(
-        execArgs.schema,
-        execArgs.document,
-        myValidationRules,
-      );
-      if (validationErrors.length > 0) {
-        return validationErrors; // return `GraphQLError[]` to send `ErrorMessage` and stop subscription
+      const errors = validate(args.schema, args.document, myValidationRules);
+      if (errors.length > 0) {
+        return errors; // return `GraphQLError[]` to send `ErrorMessage` and stop subscription
       }
 
       return args;

--- a/README.md
+++ b/README.md
@@ -538,9 +538,9 @@ createServer(
       const args = {
         schema,
         contextValue: getDynamicContext(ctx, msg),
-        operationName: msg.operationName,
-        document: parse(msg.operationName),
-        variableValues: msg.variables,
+        operationName: msg.payload.operationName,
+        document: parse(msg.payload.operationName),
+        variableValues: msg.payload.variables,
       };
 
       // dont forget to validate when returning custom execution args!

--- a/README.md
+++ b/README.md
@@ -543,6 +543,9 @@ createServer(
 );
 ```
 
+</details>
+
+<details>
 <summary>Server and client usage with persisted queries</summary>
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -498,17 +498,18 @@ server.listen(443);
 </details>
 
 <details>
-<summary>Server usage with custom GraphQL arguments</summary>
+<summary>Server usage with custom static GraphQL arguments</summary>
 
 ```typescript
 import { validate, execute, subscribe } from 'graphql';
 import { createServer } from 'graphql-transport-ws';
-import { schema } from 'my-graphql-schema';
+import { schema, roots, getStaticContext } from 'my-graphql';
 
 createServer(
   {
     context: getStaticContext(),
     schema,
+    roots,
     execute,
     subscribe,
   },
@@ -517,10 +518,17 @@ createServer(
     path: '/graphql',
   },
 );
+```
 
-// or create execution args dynamically on every subscription
+</details>
 
-import { parse } from 'graphql';
+<details>
+<summary>Server usage with custom dynamic GraphQL arguments and validation</summary>
+
+```typescript
+import { parse, validate, execute, subscribe } from 'graphql';
+import { createServer } from 'graphql-transport-ws';
+import { schema, getDynamicContext, myValidationRules } from 'my-graphql';
 
 createServer(
   {
@@ -535,8 +543,12 @@ createServer(
         variableValues: msg.variables,
       };
 
-      // if you are returning custom execution args, dont forget to validate them!
-      const validationErrors = validate(execArgs.schema, execArgs.document);
+      // dont forget to validate when returning custom execution args!
+      const validationErrors = validate(
+        execArgs.schema,
+        execArgs.document,
+        myValidationRules,
+      );
       if (validationErrors.length > 0) {
         return validationErrors; // return `GraphQLError[]` to send `ErrorMessage` and stop subscription
       }

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ server.listen(443);
 </details>
 
 <details>
-<summary>Server usage with a custom GraphQL context</summary>
+<summary>Server usage with custom GraphQL arguments</summary>
 
 ```typescript
 import { execute, subscribe } from 'graphql';
@@ -507,16 +507,33 @@ import { schema } from 'my-graphql-schema';
 
 createServer(
   {
+    context: getStaticContext(),
     schema,
     execute,
     subscribe,
-    onSubscribe: (ctx, msg, args) => {
-      return [
-        {
-          ...args,
-          contextValue: getCustomContext(ctx, msg, args),
-        },
-      ];
+  },
+  {
+    server,
+    path: '/graphql',
+  },
+);
+
+// or create execution args dynamically on every subscription
+
+import { parse } from 'graphql';
+
+createServer(
+  {
+    execute,
+    subscribe,
+    onSubscribe: (ctx, msg) => {
+      return {
+        schema,
+        contextValue: getDynamicContext(ctx, msg),
+        operationName: msg.operationName,
+        document: parse(msg.operationName),
+        variableValues: msg.variables,
+      };
     },
   },
   {

--- a/README.md
+++ b/README.md
@@ -400,29 +400,20 @@ const server = https.createServer(function weServeSocketsOnly(_, res) {
 createServer(
   {
     schema,
-    execute: async (args) => {
-      console.log('Execute', args);
-      const result = await execute(args);
-      console.debug('Execute result', result);
-      return result;
-    },
-    subscribe: async (args) => {
-      console.log('Subscribe', args);
-      const subscription = await subscribe(args);
-      // NOTE: `subscribe` can sometimes return a single result, I dont consider it here for sake of simplicity
-      return (async function* () {
-        for await (const result of subscription) {
-          console.debug('Subscribe yielded result', { args, result });
-          yield result;
-        }
-      })();
-    },
     onConnect: (ctx) => {
       console.log('Connect', ctx);
-      return true; // default behaviour - permit all connection attempts
+    },
+    onSubscribe: (ctx, msg) => {
+      console.log('Subscribe', { ctx, msg });
+    },
+    onNext: (ctx, msg, args, result) => {
+      console.debug('Next', { ctx, msg, args, result });
+    },
+    onError: (ctx, msg, errors) => {
+      console.error('Error', { ctx, msg, errors });
     },
     onComplete: (ctx, msg) => {
-      console.debug('Complete', { ctx, msg });
+      console.log('Complete', { ctx, msg });
     },
   },
   {

--- a/docs/interfaces/_server_.serveroptions.md
+++ b/docs/interfaces/_server_.serveroptions.md
@@ -94,7 +94,7 @@ ___
 
 ### onConnect
 
-• `Optional` **onConnect**: undefined \| (ctx: [Context](_server_.context.md)) => Promise\<boolean> \| boolean
+• `Optional` **onConnect**: undefined \| (ctx: [Context](_server_.context.md)) => Promise\<boolean \| void> \| boolean \| void
 
 Is the connection callback called when the
 client requests the connection initialisation
@@ -102,7 +102,7 @@ through the message `ConnectionInit`. The message
 payload (`connectionParams` on the client) is
 present in the `Context.connectionParams`.
 
-- Returning `true` from the callback will
+- Returning `true` or nothing from the callback will
 allow the client to connect.
 
 - Returning `false` from the callback will

--- a/docs/interfaces/_server_.serveroptions.md
+++ b/docs/interfaces/_server_.serveroptions.md
@@ -15,23 +15,22 @@
 * [connectionInitWaitTimeout](_server_.serveroptions.md#connectioninitwaittimeout)
 * [context](_server_.serveroptions.md#context)
 * [execute](_server_.serveroptions.md#execute)
-* [formatExecutionResult](_server_.serveroptions.md#formatexecutionresult)
 * [keepAlive](_server_.serveroptions.md#keepalive)
 * [onComplete](_server_.serveroptions.md#oncomplete)
 * [onConnect](_server_.serveroptions.md#onconnect)
+* [onError](_server_.serveroptions.md#onerror)
+* [onNext](_server_.serveroptions.md#onnext)
+* [onOperation](_server_.serveroptions.md#onoperation)
 * [onSubscribe](_server_.serveroptions.md#onsubscribe)
 * [roots](_server_.serveroptions.md#roots)
 * [schema](_server_.serveroptions.md#schema)
 * [subscribe](_server_.serveroptions.md#subscribe)
-* [validationRules](_server_.serveroptions.md#validationrules)
 
 ## Properties
 
 ### connectionInitWaitTimeout
 
 • `Optional` **connectionInitWaitTimeout**: undefined \| number
-
-**`default`** 3 * 1000 (3 seconds)
 
 The amount of time for which the
 server will wait for `ConnectionInit` message.
@@ -43,37 +42,30 @@ has not sent the `ConnectionInit` message,
 the server will terminate the socket by
 dispatching a close event `4408: Connection initialisation timeout`
 
+**`default`** 3 * 1000 (3 seconds)
+
 ___
 
 ### context
 
-• `Optional` **context**: SubscriptionArgs[\"contextValue\"]
+• `Optional` **context**: unknown
 
 A value which is provided to every resolver and holds
 important contextual information like the currently
 logged in user, or access to a database.
-Related operation context value will be injected to the
-`ExecutionArgs` BEFORE the `onSubscribe` callback.
+
+If you return from the `onSubscribe` callback, this
+context value will NOT be injected. You should add it
+in the returned `ExecutionArgs` from the callback.
 
 ___
 
 ### execute
 
-•  **execute**: (args: ExecutionArgs) => Promise\<AsyncIterableIterator\<ExecutionResult> \| ExecutionResult> \| AsyncIterableIterator\<ExecutionResult> \| ExecutionResult
+•  **execute**: (args: ExecutionArgs) => [OperationResult](../modules/_server_.md#operationresult)
 
 Is the `execute` function from GraphQL which is
-used to execute the query/mutation operation.
-
-___
-
-### formatExecutionResult
-
-• `Optional` **formatExecutionResult**: [ExecutionResultFormatter](../modules/_server_.md#executionresultformatter)
-
-Format the operation execution results
-if the implementation requires an adjusted
-result. This formatter is run BEFORE the
-`onConnect` scoped formatter.
+used to execute the query and mutation operations.
 
 ___
 
@@ -92,11 +84,11 @@ ___
 
 ### onComplete
 
-• `Optional` **onComplete**: undefined \| (ctx: [Context](_server_.context.md), message: [CompleteMessage](_message_.completemessage.md)) => void
+• `Optional` **onComplete**: undefined \| (ctx: [Context](_server_.context.md), message: [CompleteMessage](_message_.completemessage.md)) => Promise\<void> \| void
 
 The complete callback is executed after the
-operation has completed or the subscription
-has been closed.
+operation has completed right before sending
+the complete message to the client.
 
 ___
 
@@ -125,17 +117,79 @@ thrown `Error`.
 
 ___
 
+### onError
+
+• `Optional` **onError**: undefined \| (ctx: [Context](_server_.context.md), message: [ErrorMessage](_message_.errormessage.md), errors: readonly GraphQLError[]) => Promise\<readonly GraphQLError[] \| void> \| readonly GraphQLError[] \| void
+
+Executed after an error occured right before it
+has been dispatched to the client.
+
+Use this callback to format the outgoing GraphQL
+errors before they reach the client.
+
+Returned result will be injected in the error message payload.
+
+___
+
+### onNext
+
+• `Optional` **onNext**: undefined \| (ctx: [Context](_server_.context.md), message: [NextMessage](_message_.nextmessage.md), args: ExecutionArgs, result: ExecutionResult) => Promise\<ExecutionResult \| void> \| ExecutionResult \| void
+
+Executed after an operation has emitted a result right before
+that result has been sent to the client. Results from both
+single value and streaming operations will appear in this callback.
+
+Use this callback if you want to format the execution result
+before it reaches the client.
+
+Returned result will be injected in the next message payload.
+
+___
+
+### onOperation
+
+• `Optional` **onOperation**: undefined \| (ctx: [Context](_server_.context.md), message: [SubscribeMessage](_message_.subscribemessage.md), args: ExecutionArgs, result: [OperationResult](../modules/_server_.md#operationresult)) => Promise\<[OperationResult](../modules/_server_.md#operationresult) \| void> \| [OperationResult](../modules/_server_.md#operationresult) \| void
+
+Executed after the operation call resolves. For streaming
+operations, triggering this callback does not necessarely
+mean that there is already a result available - it means
+that the subscription process for the stream has resolved
+and that the client is now subscribed.
+
+The `OperationResult` argument is the result of operation
+execution. It can be an iterator or already value.
+
+If you want the single result and the events from a streaming
+operation, use the `onNext` callback.
+
+Use this callback to listen for subscribe operation and
+execution result manipulation.
+
+___
+
 ### onSubscribe
 
-• `Optional` **onSubscribe**: undefined \| (ctx: [Context](_server_.context.md), message: [SubscribeMessage](_message_.subscribemessage.md), args: Optional\<ExecutionArgs, \"schema\">) => Promise\<[ExecutionArgs, undefined \| [ExecutionResultFormatter](../modules/_server_.md#executionresultformatter)]> \| [ExecutionArgs, undefined \| [ExecutionResultFormatter](../modules/_server_.md#executionresultformatter)]
+• `Optional` **onSubscribe**: undefined \| (ctx: [Context](_server_.context.md), message: [SubscribeMessage](_message_.subscribemessage.md)) => Promise\<ExecutionArgs \| readonly GraphQLError[] \| void> \| ExecutionArgs \| readonly GraphQLError[] \| void
 
-The subscribe callback executed before
-the actual operation execution. Useful
-for manipulating the execution arguments
-before the doing the operation. As a second
-item in the array, you can pass in a scoped
-execution result formatter. This formatter
-is run AFTER the root `formatExecutionResult`.
+The subscribe callback executed right after
+acknowledging the request before any payload
+processing has been performed.
+
+If you return `ExecutionArgs` from the callback,
+it will be used instead of trying to build one
+internally. In this case, you are responsible
+for providing a ready set of arguments which will
+be directly plugged in the operation execution.
+
+To report GraphQL errors simply return an array
+of them from the callback, they will be reported
+to the client through the error message.
+
+Useful for preparing the execution arguments
+following a custom logic. A typical use case are
+persisted queries, you can identify the query from
+the subscribe message and create the GraphQL operation
+execution args which are then returned by the function.
 
 ___
 
@@ -146,8 +200,10 @@ ___
 The GraphQL root fields or resolvers to go
 alongside the schema. Learn more about them
 here: https://graphql.org/learn/execution/#root-fields-resolvers.
-Related operation root value will be injected to the
-`ExecutionArgs` BEFORE the `onSubscribe` callback.
+
+If you return from the `onSubscribe` callback, the
+root field value will NOT be injected. You should add it
+in the returned `ExecutionArgs` from the callback.
 
 ___
 
@@ -156,25 +212,17 @@ ___
 • `Optional` **schema**: GraphQLSchema
 
 The GraphQL schema on which the operations
-will be executed and validated against. If
-the schema is left undefined, one must be
-provided by in the resulting `ExecutionArgs`
-from the `onSubscribe` callback.
+will be executed and validated against.
+
+If the schema is left undefined, you're trusted to
+provide one in the returned `ExecutionArgs` from the
+`onSubscribe` callback.
 
 ___
 
 ### subscribe
 
-•  **subscribe**: (args: ExecutionArgs) => Promise\<AsyncIterableIterator\<ExecutionResult> \| ExecutionResult>
+•  **subscribe**: (args: ExecutionArgs) => [OperationResult](../modules/_server_.md#operationresult)
 
 Is the `subscribe` function from GraphQL which is
 used to execute the subscription operation.
-
-___
-
-### validationRules
-
-• `Optional` **validationRules**: readonly ValidationRule[]
-
-Custom validation rules overriding all
-validation rules defined by the GraphQL spec.

--- a/docs/modules/_message_.md
+++ b/docs/modules/_message_.md
@@ -24,6 +24,12 @@
 
 * [Message](_message_.md#message)
 
+### Functions
+
+* [isMessage](_message_.md#ismessage)
+* [parseMessage](_message_.md#parsemessage)
+* [stringifyMessage](_message_.md#stringifymessage)
+
 ## Type aliases
 
 ### Message
@@ -35,3 +41,57 @@
 Name | Type | Default |
 ------ | ------ | ------ |
 `T` | [MessageType](../enums/_message_.messagetype.md) | MessageType |
+
+## Functions
+
+### isMessage
+
+▸ **isMessage**(`val`: unknown): val is Message
+
+Checks if the provided value is a message.
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`val` | unknown |
+
+**Returns:** val is Message
+
+___
+
+### parseMessage
+
+▸ **parseMessage**(`data`: unknown): [Message](_message_.md#message)
+
+Parses the raw websocket message data to a valid message.
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`data` | unknown |
+
+**Returns:** [Message](_message_.md#message)
+
+___
+
+### stringifyMessage
+
+▸ **stringifyMessage**\<T>(`msg`: [Message](_message_.md#message)\<T>): string
+
+Stringifies a valid message ready to be sent through the socket.
+
+#### Type parameters:
+
+Name | Type |
+------ | ------ |
+`T` | [MessageType](../enums/_message_.messagetype.md) |
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`msg` | [Message](_message_.md#message)\<T> |
+
+**Returns:** string

--- a/docs/modules/_server_.md
+++ b/docs/modules/_server_.md
@@ -14,7 +14,7 @@
 
 ### Type aliases
 
-* [ExecutionResultFormatter](_server_.md#executionresultformatter)
+* [OperationResult](_server_.md#operationresult)
 
 ### Functions
 
@@ -22,9 +22,9 @@
 
 ## Type aliases
 
-### ExecutionResultFormatter
+### OperationResult
 
-Ƭ  **ExecutionResultFormatter**: (ctx: [Context](../interfaces/_server_.context.md), result: ExecutionResult) => Promise\<ExecutionResult> \| ExecutionResult
+Ƭ  **OperationResult**: Promise\<AsyncIterableIterator\<ExecutionResult> \| ExecutionResult> \| AsyncIterableIterator\<ExecutionResult> \| ExecutionResult
 
 ## Functions
 

--- a/src/message.ts
+++ b/src/message.ts
@@ -82,7 +82,7 @@ export type Message<
 export function isMessage(val: unknown): val is Message {
   if (isObject(val)) {
     // all messages must have the `type` prop
-    if (!hasOwnProperty(val, 'type')) {
+    if (!hasOwnStringProperty(val, 'type')) {
       return false;
     }
     // validate other properties depending on the `type`

--- a/src/message.ts
+++ b/src/message.ts
@@ -7,10 +7,10 @@
 import { GraphQLError, ExecutionResult, DocumentNode } from 'graphql';
 import {
   isObject,
+  areGraphQLErrors,
   hasOwnProperty,
   hasOwnObjectProperty,
   hasOwnStringProperty,
-  hasOwnArrayProperty,
 } from './utils';
 
 /** Types of messages allowed to be sent by the client/server over the WS protocol. */
@@ -116,12 +116,7 @@ export function isMessage(val: unknown): val is Message {
             hasOwnObjectProperty(val.payload, 'errors'))
         );
       case MessageType.Error:
-        return (
-          hasOwnStringProperty(val, 'id') &&
-          // GraphQLError
-          hasOwnArrayProperty(val, 'payload') &&
-          val.payload.length > 0 // must be at least one error
-        );
+        return hasOwnStringProperty(val, 'id') && areGraphQLErrors(val.payload);
       case MessageType.Complete:
         return hasOwnStringProperty(val, 'id');
       default:

--- a/src/message.ts
+++ b/src/message.ts
@@ -78,7 +78,7 @@ export type Message<
   ? CompleteMessage
   : never;
 
-/** @ignore */
+/** Checks if the provided value is a message. */
 export function isMessage(val: unknown): val is Message {
   if (isObject(val)) {
     // all messages must have the `type` prop
@@ -102,7 +102,7 @@ export function isMessage(val: unknown): val is Message {
           hasOwnObjectProperty(val, 'payload') &&
           (!hasOwnProperty(val.payload, 'operationName') ||
             hasOwnStringProperty(val.payload, 'operationName')) &&
-          (hasOwnStringProperty(val.payload, 'query') || // string query
+          (hasOwnStringProperty(val.payload, 'query') || // string query or persisted query id
             hasOwnObjectProperty(val.payload, 'query')) && // document node query
           (!hasOwnProperty(val.payload, 'variables') ||
             hasOwnObjectProperty(val.payload, 'variables'))
@@ -126,7 +126,7 @@ export function isMessage(val: unknown): val is Message {
   return false;
 }
 
-/** @ignore */
+/** Parses the raw websocket message data to a valid message. */
 export function parseMessage(data: unknown): Message {
   if (isMessage(data)) {
     return data;
@@ -141,10 +141,7 @@ export function parseMessage(data: unknown): Message {
   return message;
 }
 
-/**
- * @ignore
- * Helps stringifying a valid message ready to be sent through the socket.
- */
+/** Stringifies a valid message ready to be sent through the socket. */
 export function stringifyMessage<T extends MessageType>(
   msg: Message<T>,
 ): string {

--- a/src/server.ts
+++ b/src/server.ts
@@ -118,7 +118,7 @@ export interface ServerOptions {
    * payload (`connectionParams` on the client) is
    * present in the `Context.connectionParams`.
    *
-   * - Returning `true` from the callback will
+   * - Returning `true` or nothing from the callback will
    * allow the client to connect.
    *
    * - Returning `false` from the callback will
@@ -131,7 +131,7 @@ export interface ServerOptions {
    * the `<error-message>` is the message of the
    * thrown `Error`.
    */
-  onConnect?: (ctx: Context) => Promise<boolean> | boolean;
+  onConnect?: (ctx: Context) => Promise<boolean | void> | boolean | void;
   /**
    * The subscribe callback executed right after
    * acknowledging the request before any payload
@@ -422,7 +422,7 @@ export function createServer(
 
             if (onConnect) {
               const permitted = await onConnect(ctx);
-              if (!permitted) {
+              if (permitted === false) {
                 return ctx.socket.close(4403, 'Forbidden');
               }
             }

--- a/src/server.ts
+++ b/src/server.ts
@@ -156,7 +156,11 @@ export interface ServerOptions {
   onSubscribe?: (
     ctx: Context,
     message: SubscribeMessage,
-  ) => ExecutionArgs | readonly GraphQLError[] | void;
+  ) =>
+    | Promise<ExecutionArgs | readonly GraphQLError[] | void>
+    | ExecutionArgs
+    | readonly GraphQLError[]
+    | void;
   /**
    * Executed after the operation call resolves. For streaming
    * operations, triggering this callback does not necessarely
@@ -191,7 +195,7 @@ export interface ServerOptions {
     ctx: Context,
     message: ErrorMessage,
     errors: readonly GraphQLError[],
-  ) => readonly GraphQLError[] | void;
+  ) => Promise<readonly GraphQLError[] | void> | readonly GraphQLError[] | void;
   /**
    * Executed after an operation has emitted a result right before
    * that result has been sent to the client. Results from both
@@ -207,13 +211,13 @@ export interface ServerOptions {
     message: NextMessage,
     args: ExecutionArgs,
     result: ExecutionResult,
-  ) => ExecutionResult | void;
+  ) => Promise<ExecutionResult | void> | ExecutionResult | void;
   /**
    * The complete callback is executed after the
    * operation has completed right before sending
    * the complete message to the client.
    */
-  onComplete?: (ctx: Context, message: CompleteMessage) => void;
+  onComplete?: (ctx: Context, message: CompleteMessage) => Promise<void> | void;
 }
 
 export interface Context {
@@ -464,11 +468,11 @@ export function createServer(
                   payload: errors,
                 };
                 if (onError) {
-                  const maybeErrors = await onError(ctx, errorMessage, errors);
-                  if (maybeErrors) {
+                  const maybeResult = await onError(ctx, errorMessage, errors);
+                  if (maybeResult) {
                     errorMessage = {
                       ...errorMessage,
-                      payload: maybeErrors,
+                      payload: maybeResult,
                     };
                   }
                 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -180,6 +180,7 @@ export interface ServerOptions {
   onOperation?: (
     ctx: Context,
     message: SubscribeMessage,
+    args: ExecutionArgs,
     result: OperationResult,
   ) => Promise<OperationResult | void> | OperationResult | void;
   /**
@@ -554,6 +555,7 @@ export function createServer(
               const maybeResult = await onOperation(
                 ctx,
                 message,
+                execArgs,
                 operationResult,
               );
               if (maybeResult) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -493,7 +493,7 @@ export function createServer(
             const maybeExecArgsOrErrors = await onSubscribe?.(ctx, message);
             if (maybeExecArgsOrErrors) {
               if (areGraphQLErrors(maybeExecArgsOrErrors)) {
-                return emit.error(maybeExecArgsOrErrors);
+                return await emit.error(maybeExecArgsOrErrors);
               }
               execArgs = maybeExecArgsOrErrors as ExecutionArgs; // because not graphql errors
             } else {
@@ -521,7 +521,7 @@ export function createServer(
                 execArgs.document,
               );
               if (validationErrors.length > 0) {
-                return emit.error(validationErrors);
+                return await emit.error(validationErrors);
               }
             }
 
@@ -530,7 +530,7 @@ export function createServer(
               execArgs.operationName,
             );
             if (!operationAST) {
-              return emit.error([
+              return await emit.error([
                 new GraphQLError('Unable to identify operation'),
               ]);
             }

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -8,7 +8,7 @@ import { Server } from '../server';
 import { createClient, EventListener } from '../client';
 
 // Just does nothing
-export function noop(): void {
+function noop(): void {
   /**/
 }
 

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -3,7 +3,6 @@ import { parse, buildSchema, execute, subscribe } from 'graphql';
 import { GRAPHQL_TRANSPORT_WS_PROTOCOL } from '../protocol';
 import { MessageType, parseMessage, stringifyMessage } from '../message';
 import { startServer, url, schema, pong } from './fixtures/simple';
-import { noop } from './client';
 
 let forgottenDispose: (() => Promise<void>) | undefined;
 async function makeServer(

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -5,7 +5,6 @@ import {
   MessageType,
   parseMessage,
   stringifyMessage,
-  SubscribeMessage,
   SubscribePayload,
 } from '../message';
 import { startServer, url, schema, pong } from './fixtures/simple';

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -379,7 +379,7 @@ describe('Connect', () => {
     });
   });
 
-  it('should acknowledge connection if not implemented or returning `true`', async () => {
+  it('should acknowledge connection if not implemented, returning `true` or nothing', async () => {
     async function test() {
       const client = await createTClient();
       client.ws.send(
@@ -393,15 +393,23 @@ describe('Connect', () => {
     }
 
     // no implementation
-    const [, dispose] = await makeServer();
+    let [, dispose] = await makeServer();
     await test();
-
     await dispose();
 
     // returns true
-    await makeServer({
+    [, dispose] = await makeServer({
       onConnect: () => {
         return true;
+      },
+    });
+    await test();
+    await dispose();
+
+    // returns nothing
+    await makeServer({
+      onConnect: () => {
+        /**/
       },
     });
     await test();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,19 +6,26 @@
 
 export type Optional<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>> &
   Partial<Pick<T, K>>;
+import { GraphQLError } from 'graphql';
 
 export function isObject(val: unknown): val is Record<PropertyKey, unknown> {
   return typeof val === 'object' && val !== null;
-}
-
-export function isArray(val: unknown): val is unknown[] {
-  return typeof val === 'object' && val !== null && Array.isArray(val);
 }
 
 export function isAsyncIterable<T = unknown>(
   val: unknown,
 ): val is AsyncIterableIterator<T> {
   return typeof Object(val)[Symbol.asyncIterator] === 'function';
+}
+
+export function areGraphQLErrors(obj: unknown): obj is GraphQLError[] {
+  return (
+    Array.isArray(obj) &&
+    // must be at least one error
+    obj.length > 0 &&
+    // error has at least a message
+    obj.every((ob) => 'message' in ob)
+  );
 }
 
 export function hasOwnProperty<
@@ -39,7 +46,9 @@ export function hasOwnArrayProperty<
   O extends Record<PropertyKey, unknown>,
   P extends PropertyKey
 >(obj: O, prop: P): obj is O & Record<P, unknown[]> {
-  return Object.prototype.hasOwnProperty.call(obj, prop) && isArray(obj[prop]);
+  return (
+    Object.prototype.hasOwnProperty.call(obj, prop) && Array.isArray(obj[prop])
+  );
 }
 
 export function hasOwnStringProperty<

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,9 +3,6 @@
  * utils
  *
  */
-
-export type Optional<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>> &
-  Partial<Pick<T, K>>;
 import { GraphQLError } from 'graphql';
 
 export function isObject(val: unknown): val is Record<PropertyKey, unknown> {


### PR DESCRIPTION
Closes #37, re-closes #27 and helps with #39

This PR comes along with some worthwhile breaking changes. One key change is trusting the execution arguments returned from the `onSubscribe` callback implicitly. This allows for all sorts of enhancements, some of them being:
- Persisted queries (has recipe)
- Increased validation process customisability (has recipe)
- Performance optimisations with custom subscription handling

### Breaking changes
- `onSubscribe` now executes _before_ any other subscribe message processing
- `onSubscribe` now takes 2 arguments, the context and the subscribe message
- `onSubscribe` now returns nothing,`ExecutionArgs` or an array of `GraphQLError`s
  - Returning `void` (or nothing) will leave the execution args preparation and validation to the library
  - Returned `ExecutionArgs` will be used **directly** for the GraphQL operation execution (preparations and validation should be done by you if you decide to provide the args yourself)
  - Returned array of `GraphQLError`s will be reported to the client through the error message
- `validationRules` have been dropped in favour of applying custom validation rules in the `onSubscribe` callback (has recipe)
- `formatExecutionResult` has been dropped in favour of using the `onNext` callback

### TODO
- [x] Adapt tests for new `onSubscribe` callback
- [x] Test new expected behaviour
- [x] Adapt `onSubscribe` logging recipes
- [x] Add persisted query recipe
- [x] Add custom validation recipe
- [x] Improve logging recipe